### PR TITLE
Adjusted the CSS for weekend day cells in the calendar.

### DIFF
--- a/planning-dates-calculator.html
+++ b/planning-dates-calculator.html
@@ -237,7 +237,8 @@
         /* Professional weekend styling with pill effect */
         .calendar-grid-container .calendar-grid-day-cell.weekend {
             position: relative;
-            background-color: rgba(3, 6, 69, 0.03);
+            background-color: rgba(3, 6, 69, 0.02);
+            border: 1px solid rgba(3, 6, 69, 0.1);
         }
         
         /* Weekend styling for day numbers: Individual pill effect */


### PR DESCRIPTION
- Added a 1px solid light navy border.
- Lightened the background color to rgba(3, 6, 69, 0.02).

These changes aim to make weekends more distinct from past day shading while maintaining a professional look, as per your request.